### PR TITLE
Add sample Vue SPA and .NET Core API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # POMS
+
+This repository contains a sample Vue single page application (SPA) and a C# ASP.NET Core API backend.
+
+## Backend
+
+The backend project is located in the `backend` folder. It exposes a single API endpoint `/api/orders` that returns ten sample purchase orders.
+
+To build and run the API you need the .NET 6 SDK installed:
+
+```bash
+cd backend
+dotnet run
+```
+
+## Frontend
+
+The frontend is a minimal Vue application located in the `frontend` folder. It fetches the orders from the backend and displays them in a table.
+
+To serve the static files you can use any HTTP server. For example:
+
+```bash
+cd frontend
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080` in your browser.
+

--- a/backend/Order.cs
+++ b/backend/Order.cs
@@ -1,0 +1,12 @@
+namespace PomsApi;
+
+public record Order(
+    string PoNumber,
+    int OrderQty,
+    int ShipQty,
+    string Shipper,
+    string Consignee,
+    string From,
+    string To,
+    string HouseNo,
+    string Shipway);

--- a/backend/PomsApi.csproj
+++ b/backend/PomsApi.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,22 @@
+using PomsApi;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+var orders = new List<Order>
+{
+    new("PO001", 10, 5, "Shipper A", "Consignee A", "Los Angeles", "New York", "H001", "Air"),
+    new("PO002", 20, 20, "Shipper B", "Consignee B", "Chicago", "Houston", "H002", "Road"),
+    new("PO003", 15, 15, "Shipper C", "Consignee C", "Seattle", "Miami", "H003", "Sea"),
+    new("PO004", 40, 30, "Shipper D", "Consignee D", "London", "Paris", "H004", "Rail"),
+    new("PO005", 50, 50, "Shipper E", "Consignee E", "Tokyo", "Osaka", "H005", "Sea"),
+    new("PO006", 60, 45, "Shipper F", "Consignee F", "Beijing", "Shanghai", "H006", "Air"),
+    new("PO007", 70, 70, "Shipper G", "Consignee G", "Dubai", "Berlin", "H007", "Road"),
+    new("PO008", 80, 70, "Shipper H", "Consignee H", "Sydney", "Melbourne", "H008", "Sea"),
+    new("PO009", 90, 80, "Shipper I", "Consignee I", "Mumbai", "Delhi", "H009", "Air"),
+    new("PO010", 100, 90, "Shipper J", "Consignee J", "San Francisco", "Las Vegas", "H010", "Rail")
+};
+
+app.MapGet("/api/orders", () => orders);
+
+app.Run();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,14 @@
+const { createApp } = Vue;
+
+createApp({
+  data() {
+    return { orders: [] };
+  },
+  mounted() {
+    fetch('/api/orders')
+      .then(res => res.json())
+      .then(data => {
+        this.orders = data;
+      });
+  }
+}).mount('#app');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Orders</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <div id="app">
+    <table border="1">
+      <thead>
+        <tr>
+          <th>PO number</th>
+          <th>Order QTY</th>
+          <th>Ship QTY</th>
+          <th>Shipper</th>
+          <th>Consignee</th>
+          <th>From</th>
+          <th>To</th>
+          <th>House no</th>
+          <th>Shipway</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="order in orders" :key="order.poNumber">
+          <td>{{ order.poNumber }}</td>
+          <td>{{ order.orderQty }}</td>
+          <td>{{ order.shipQty }}</td>
+          <td>{{ order.shipper }}</td>
+          <td>{{ order.consignee }}</td>
+          <td>{{ order.from }}</td>
+          <td>{{ order.to }}</td>
+          <td>{{ order.houseNo }}</td>
+          <td>{{ order.shipway }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple ASP.NET Core API returning 10 sample orders
- add Vue SPA that fetches the API and renders a table
- update README with setup instructions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7eb6ed5c8320abf84dab744d0bba